### PR TITLE
Feat/binary roles

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,0 +1,36 @@
+name: Cairo static analysis
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Python setup
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
+          cache: pip
+          cache-dependency-path: "**/requirements.txt"
+
+      - name: Env setup
+        run: pip install -r requirements.txt
+
+      - name: Install Amarna
+        run: git clone https://github.com/crytic/amarna.git && cd amarna && pip install -e .
+
+      - name: Run Amarna static analysis
+        run: amarna contracts/ -o out.sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: out.sarif

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: test
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container: ghcr.io/dopedao/ryo:latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: install extra python dependencies
+        run: pip3 install -U 'pytest-xdist[psutil]' dill cairo-lang==0.10.0 cairo-nile==0.10.0
+      - name: compile
+        run: scripts/compile
+      - name: test
+        run: scripts/test
+
+  protostar-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install Protostar
+        uses: sambarnes/protostar-toolchain@main
+
+      - name: Run protostar tests
+        run: protostar test ./tests/protostar

--- a/contracts/access_control/accesscontrol_library.cairo
+++ b/contracts/access_control/accesscontrol_library.cairo
@@ -1,0 +1,196 @@
+%lang starknet
+
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
+from starkware.cairo.common.bitwise import bitwise_and, bitwise_not, bitwise_or
+from starkware.cairo.common.bool import TRUE
+from starkware.cairo.common.math_cmp import is_not_zero
+
+from contracts.access_control.aliases import address, bool, ufelt
+
+//
+// Events
+//
+
+@event
+func RoleGranted(role: ufelt, account: address) {
+}
+
+@event
+func RoleRevoked(role: ufelt, account: address) {
+}
+
+@event
+func AdminChanged(prev_admin: address, new_admin: address) {
+}
+
+//
+// Storage
+//
+
+@storage_var
+func accesscontrol_admin() -> (admin: address) {
+}
+
+@storage_var
+func accesscontrol_roles(account: address) -> (role: ufelt) {
+}
+
+namespace AccessControl {
+    //
+    // Initializer
+    //
+
+    func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        admin: address
+    ) {
+        _set_admin(admin);
+        return ();
+    }
+
+    //
+    // Modifier
+    //
+
+    func assert_has_role{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr,
+        bitwise_ptr: BitwiseBuiltin*,
+    }(role: ufelt) {
+        alloc_locals;
+        let (caller: address) = get_caller_address();
+        let authorized: bool = has_role(role, caller);
+        with_attr error_message("AccessControl: caller is missing role {role}") {
+            assert authorized = TRUE;
+        }
+        return ();
+    }
+
+    func assert_admin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        alloc_locals;
+        let (caller: address) = get_caller_address();
+        let admin: address = accesscontrol_admin.read();
+        with_attr error_message("AccessControl: caller is not admin") {
+            assert caller = admin;
+        }
+        return ();
+    }
+
+    //
+    // Getters
+    //
+
+    func get_roles{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        account: address
+    ) -> ufelt {
+        let (roles: ufelt) = accesscontrol_roles.read(account);
+        return roles;
+    }
+
+    func has_role{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr,
+        bitwise_ptr: BitwiseBuiltin*,
+    }(role: ufelt, account: address) -> bool {
+        let (roles: ufelt) = accesscontrol_roles.read(account);
+        // masks roles such that all bits are zero, except the bit(s) representing `role`, which may be zero or one
+        let (masked_roles: ufelt) = bitwise_and(roles, role);
+        let authorized: bool = is_not_zero(masked_roles);
+        return authorized;
+    }
+
+    func get_admin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> address {
+        let (admin: address) = accesscontrol_admin.read();
+        return admin;
+    }
+
+    //
+    // Externals
+    //
+
+    func grant_role{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr,
+        bitwise_ptr: BitwiseBuiltin*,
+    }(role: ufelt, account: address) {
+        assert_admin();
+        _grant_role(role, account);
+        return ();
+    }
+
+    func revoke_role{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr,
+        bitwise_ptr: BitwiseBuiltin*,
+    }(role, account) {
+        assert_admin();
+        _revoke_role(role, account);
+        return ();
+    }
+
+    func renounce_role{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr,
+        bitwise_ptr: BitwiseBuiltin*,
+    }(role: ufelt, account: address) {
+        let (caller: address) = get_caller_address();
+        with_attr error_message("AccessControl: can only renounce roles for self") {
+            assert account = caller;
+        }
+        _revoke_role(role, account);
+        return ();
+    }
+
+    func change_admin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        new_admin: address
+    ) {
+        assert_admin();
+        _set_admin(new_admin);
+        return ();
+    }
+
+    //
+    // Unprotected
+    //
+
+    func _grant_role{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr,
+        bitwise_ptr: BitwiseBuiltin*,
+    }(role: ufelt, account: address) {
+        let (roles: ufelt) = accesscontrol_roles.read(account);
+        let (updated_roles: ufelt) = bitwise_or(roles, role);
+        accesscontrol_roles.write(account, updated_roles);
+        RoleGranted.emit(role, account);
+        return ();
+    }
+
+    func _revoke_role{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr,
+        bitwise_ptr: BitwiseBuiltin*,
+    }(role: ufelt, account: address) {
+        let (roles: ufelt) = accesscontrol_roles.read(account);
+        let (revoked_complement: ufelt) = bitwise_not(role);
+        let (updated_roles: ufelt) = bitwise_and(roles, revoked_complement);
+        accesscontrol_roles.write(account, updated_roles);
+        RoleRevoked.emit(role, account);
+        return ();
+    }
+
+    func _set_admin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        new_admin: address
+    ) {
+        let prev_admin: address = accesscontrol_admin.read();
+        accesscontrol_admin.write(new_admin);
+        AdminChanged.emit(prev_admin, new_admin);
+        return ();
+    }
+}

--- a/contracts/access_control/accesscontrol_library.cairo
+++ b/contracts/access_control/accesscontrol_library.cairo
@@ -4,6 +4,7 @@ from starkware.starknet.common.syscalls import get_caller_address
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin
 from starkware.cairo.common.bitwise import bitwise_and, bitwise_not, bitwise_or
 from starkware.cairo.common.bool import TRUE
+from starkware.cairo.common.math import assert_not_equal
 from starkware.cairo.common.math_cmp import is_not_zero
 
 from contracts.access_control.aliases import address, bool, ufelt
@@ -116,7 +117,12 @@ namespace AccessControl {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(role: ufelt, account: address) {
-        assert_admin();
+        // Change from AccessControl Admin to guild ADMIN
+        // assert_admin();
+        let (admin) = accesscontrol_admin.read();
+        with_attr error_message("AccessControl: cannot change master role") {
+            assert_not_equal(account, admin);
+        }
         _grant_role(role, account);
         return ();
     }
@@ -127,7 +133,12 @@ namespace AccessControl {
         range_check_ptr,
         bitwise_ptr: BitwiseBuiltin*,
     }(role, account) {
-        assert_admin();
+        // Change from AccessControl Admin to guild ADMIN
+        // assert_admin();
+        let (admin) = accesscontrol_admin.read();
+        with_attr error_message("AccessControl: cannot change master role") {
+            assert_not_equal(account, admin);
+        }
         _revoke_role(role, account);
         return ();
     }

--- a/contracts/access_control/aliases.cairo
+++ b/contracts/access_control/aliases.cairo
@@ -1,0 +1,3 @@
+using bool = felt;  // 0 or 1
+using address = felt;  // a StarkNet address
+using ufelt = felt;  // 'regular' felt

--- a/contracts/guild_certificate.cairo
+++ b/contracts/guild_certificate.cairo
@@ -36,11 +36,11 @@ struct Token {
 //
 
 @event
-func MintCertificate(account: felt, role: felt, guild: felt, id: Uint256) {
+func MintCertificate(account: felt, guild: felt, id: Uint256) {
 }
 
 @event
-func BurnCertificate(account: felt, role: felt, guild: felt, id: Uint256) {
+func BurnCertificate(account: felt, guild: felt, id: Uint256) {
 }
 
 //
@@ -57,10 +57,6 @@ func _certificate_id_count() -> (res: Uint256) {
 
 @storage_var
 func _certificate_id(owner: felt, guild: felt) -> (res: Uint256) {
-}
-
-@storage_var
-func _role(certificate_id: Uint256) -> (res: felt) {
 }
 
 @storage_var
@@ -239,14 +235,6 @@ func get_certificate_id{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_ch
 }
 
 @view
-func get_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    certificate_id: Uint256
-) -> (role: felt) {
-    let (value) = _role.read(certificate_id);
-    return (value,);
-}
-
-@view
 func get_guild{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     certificate_id: Uint256
 ) -> (guild: felt) {
@@ -324,7 +312,7 @@ func transfer_ownership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_ch
 
 @external
 func mint{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
-    to: felt, guild: felt, role: felt
+    to: felt, guild: felt
 ) {
     assert_only_guild();
 
@@ -333,23 +321,12 @@ func mint{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
     _certificate_id_count.write(new_certificate_id);
 
     _certificate_id.write(to, guild, new_certificate_id);
-    _role.write(new_certificate_id, role);
     _guild.write(new_certificate_id, guild);
 
     ERC721._mint(to, new_certificate_id);
 
-    MintCertificate.emit(to, role, guild, new_certificate_id);
+    MintCertificate.emit(to, guild, new_certificate_id);
 
-    return ();
-}
-
-@external
-func update_role{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
-    certificate_id: Uint256, role: felt
-) {
-    assert_only_guild();
-
-    _role.write(certificate_id, role);
     return ();
 }
 
@@ -359,12 +336,10 @@ func burn{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
 ) {
     alloc_locals;
     let (certificate_id: Uint256) = _certificate_id.read(account, guild);
-    let (role) = _role.read(certificate_id);
     ERC721.assert_only_token_owner(certificate_id);
-    _role.write(certificate_id, 0);
     _guild.write(certificate_id, 0);
     ERC721._burn(certificate_id);
-    BurnCertificate.emit(account, role, guild, certificate_id);
+    BurnCertificate.emit(account, guild, certificate_id);
     return ();
 }
 
@@ -375,11 +350,9 @@ func guild_burn{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}
     alloc_locals;
     assert_only_guild();
     let (certificate_id: Uint256) = _certificate_id.read(account, guild);
-    let (role) = _role.read(certificate_id);
-    _role.write(certificate_id, 0);
     _guild.write(certificate_id, 0);
     ERC721._burn(certificate_id);
-    BurnCertificate.emit(account, role, guild, certificate_id);
+    BurnCertificate.emit(account, guild, certificate_id);
     return ();
 }
 

--- a/contracts/guild_contract.cairo
+++ b/contracts/guild_contract.cairo
@@ -232,6 +232,14 @@ func get_nonce{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     return (res=res);
 }
 
+@view
+func has_role{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, bitwise_ptr: BitwiseBuiltin*
+}(role: felt, account: felt) -> (has_role: felt) {
+    let has_role = AccessControl.has_role(role, account);
+    return (has_role,);
+}
+
 //
 // Externals
 //

--- a/contracts/guild_contract.cairo
+++ b/contracts/guild_contract.cairo
@@ -2,7 +2,7 @@
 %lang starknet
 
 from starkware.cairo.common.alloc import alloc
-from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin, SignatureBuiltin
 from starkware.cairo.common.cairo_keccak.keccak import keccak_felts
 from starkware.cairo.common.math import assert_le, assert_lt
 from starkware.cairo.common.memcpy import memcpy
@@ -21,6 +21,7 @@ from openzeppelin.token.erc721.IERC721 import IERC721
 from contracts.interfaces.IERC1155 import IERC1155
 from contracts.interfaces.IGuildCertificate import IGuildCertificate
 
+from contracts.access_control.accesscontrol_library import AccessControl
 from contracts.lib.role import GuildRoles
 from contracts.lib.token_standard import TokenStandard
 from contracts.lib.math_utils import MathUtils
@@ -62,11 +63,6 @@ struct Permission {
     selector: felt,
 }
 
-struct Member {
-    account: felt,
-    role: felt,
-}
-
 struct Token {
     token_standard: felt,
     token: felt,
@@ -79,7 +75,7 @@ struct Token {
 //
 
 @event
-func MemberWhitelisted(account: felt, role: felt) {
+func MemberAdded(account: felt, role: felt) {
 }
 
 @event
@@ -129,19 +125,7 @@ func _name() -> (res: felt) {
 }
 
 @storage_var
-func _guild_master() -> (res: felt) {
-}
-
-@storage_var
 func _is_permissions_initialized() -> (res: felt) {
-}
-
-@storage_var
-func _whitelisted_role(account: felt) -> (res: felt) {
-}
-
-@storage_var
-func _is_whitelisted(account: felt) -> (res: felt) {
 }
 
 @storage_var
@@ -164,106 +148,6 @@ func _current_nonce() -> (res: felt) {
 // Guards
 //
 
-func require_master{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
-    alloc_locals;
-    let (caller) = get_caller_address();
-    let (master) = _guild_master.read();
-
-    with_attr error_message("Guild Contract: Caller is not guild master") {
-        assert caller = master;
-    }
-    return ();
-}
-
-func require_admin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
-    alloc_locals;
-    let (caller_address) = get_caller_address();
-    let (contract_address) = get_contract_address();
-    let (guild_certificate) = _guild_certificate.read();
-
-    let (certificate_id: Uint256) = IGuildCertificate.get_certificate_id(
-        contract_address=guild_certificate, owner=caller_address, guild=contract_address
-    );
-
-    let (_role) = IGuildCertificate.get_role(
-        contract_address=guild_certificate, certificate_id=certificate_id
-    );
-
-    with_attr error_message("Guild Contract: Caller is not admin") {
-        assert _role = GuildRoles.ADMIN;
-    }
-    return ();
-}
-
-func require_member{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
-    alloc_locals;
-    let (caller_address) = get_caller_address();
-    let (contract_address) = get_contract_address();
-    let (guild_certificate) = _guild_certificate.read();
-
-    let (certificate_id: Uint256) = IGuildCertificate.get_certificate_id(
-        contract_address=guild_certificate, owner=caller_address, guild=contract_address
-    );
-
-    let (check) = uint256_lt(Uint256(0, 0), certificate_id);
-
-    with_attr error_mesage("Guild Contract: Caller must have access") {
-        assert check = TRUE;
-    }
-    return ();
-}
-
-func require_admin_or_owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
-    alloc_locals;
-    let (caller_address) = get_caller_address();
-    let (contract_address) = get_contract_address();
-    let (guild_certificate) = _guild_certificate.read();
-
-    let (certificate_id: Uint256) = IGuildCertificate.get_certificate_id(
-        contract_address=guild_certificate, owner=caller_address, guild=contract_address
-    );
-
-    let (_role) = IGuildCertificate.get_role(
-        contract_address=guild_certificate, certificate_id=certificate_id
-    );
-
-    if (_role == GuildRoles.OWNER) {
-        let check_owner = TRUE;
-        tempvar check_owner = check_owner;
-    } else {
-        let check_owner = FALSE;
-        tempvar check_owner = check_owner;
-    }
-
-    if (_role == GuildRoles.ADMIN) {
-        let check_admin = TRUE;
-        tempvar check_admin = check_admin;
-    } else {
-        let check_admin = FALSE;
-        tempvar check_admin = check_admin;
-    }
-
-    let check_owner_or_admin = check_owner + check_admin;
-
-    with_attr error_message("Guild Contract: Caller is not admin or owner") {
-        assert_lt(0, check_owner_or_admin);
-    }
-
-    return ();
-}
-
-func require_not_whitelisted{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    account: felt
-) {
-    let (bool) = _is_whitelisted.read(account);
-
-    with_attr error_mesage("Guild Contract: Account is already whitelisted") {
-        assert bool = FALSE;
-    }
-
-    return ();
-}
-
 func require_not_blacklisted{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     account: felt
 ) {
@@ -285,16 +169,16 @@ func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
     name: felt, master: felt, guild_certificate: felt, proxy_admin: felt
 ) {
     _name.write(name);
-    _guild_master.write(master);
     _guild_certificate.write(guild_certificate);
 
     let (contract_address) = get_contract_address();
 
     IGuildCertificate.mint(
-        contract_address=guild_certificate, to=master, guild=contract_address, role=GuildRoles.ADMIN
+        contract_address=guild_certificate, to=master, guild=contract_address
     );
 
     Proxy.initializer(proxy_admin);
+    AccessControl._set_admin(master);
 
     ERC165.register_interface(IACCOUNT_ID);
     return ();
@@ -328,12 +212,6 @@ func name{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> 
 }
 
 @view
-func master{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (master: felt) {
-    let (master) = _guild_master.read();
-    return (master,);
-}
-
-@view
 func guild_certificate{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
     guild_certificate: felt
 ) {
@@ -354,63 +232,35 @@ func get_nonce{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     return (res=res);
 }
 
-@view
-func get_whitelisted_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    account: felt
-) -> (res: felt) {
-    let (role) = _whitelisted_role.read(account);
-
-    return (res=role);
-}
-
 //
 // Externals
 //
 
 @external
-func whitelist_member{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    memb: Member
+func add_member{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, bitwise_ptr: BitwiseBuiltin*, range_check_ptr}(
+    account: felt, role: felt
 ) {
-    require_master();
-
-    require_not_whitelisted(memb.account);
-
-    let account = memb.account;
-    let role = memb.role;
-
-    _is_whitelisted.write(account, TRUE);
-    _whitelisted_role.write(account, role);
-
-    MemberWhitelisted.emit(account=memb.account, role=memb.role);
-
-    return ();
-}
-
-@external
-func join{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
     let (guild_certificate) = _guild_certificate.read();
     let (contract_address) = get_contract_address();
     let (caller_address) = get_caller_address();
-
-    let (whitelisted_role) = _whitelisted_role.read(caller_address);
-    with_attr error_mesage("Guild Contract: Caller is not whitelisted") {
-        assert_lt(0, whitelisted_role);
-    }
 
     require_not_blacklisted(caller_address);
 
     IGuildCertificate.mint(
         contract_address=guild_certificate,
-        to=caller_address,
-        guild=contract_address,
-        role=whitelisted_role,
+        to=account,
+        guild=contract_address
     );
+
+    AccessControl.grant_role(role, account);
+
+    MemberAdded.emit(account, role);
 
     return ();
 }
 
 @external
-func leave{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+func leave{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, bitwise_ptr: BitwiseBuiltin*, range_check_ptr}() {
     let (guild_certificate) = _guild_certificate.read();
     let (contract_address) = get_contract_address();
     let (caller_address) = get_caller_address();
@@ -431,18 +281,21 @@ func leave{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
         contract_address=guild_certificate, account=caller_address, guild=contract_address
     );
 
+    let roles: felt = AccessControl.get_roles(caller_address);
+    AccessControl.revoke_role(roles, caller_address);
+
     return ();
 }
 
 @external
-func remove_member{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(account: felt) {
+func remove_member{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, bitwise_ptr: BitwiseBuiltin*, range_check_ptr}(account: felt) {
     alloc_locals;
-
-    require_admin();
 
     let (caller_address) = get_caller_address();
     let (contract_address) = get_contract_address();
     let (guild_certificate) = _guild_certificate.read();
+
+    AccessControl.has_role(GuildRoles.ADMIN, caller_address);
 
     let (certificate_id: Uint256) = IGuildCertificate.get_certificate_id(
         contract_address=guild_certificate, owner=account, guild=contract_address
@@ -457,6 +310,8 @@ func remove_member{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_p
         IGuildCertificate.guild_burn(
             contract_address=guild_certificate, account=account, guild=contract_address
         );
+        let roles: felt = AccessControl.get_roles(account);
+        AccessControl.revoke_role(roles, account);
         _is_blacklisted.write(account, TRUE);
         tempvar syscall_ptr: felt* = syscall_ptr;
         tempvar pedersen_ptr: HashBuiltin* = pedersen_ptr;
@@ -465,6 +320,8 @@ func remove_member{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_p
         IGuildCertificate.guild_burn(
             contract_address=guild_certificate, account=account, guild=contract_address
         );
+        let roles: felt = AccessControl.get_roles(account);
+        AccessControl.revoke_role(roles, account);
         _is_blacklisted.write(account, TRUE);
         tempvar syscall_ptr: felt* = syscall_ptr;
         tempvar pedersen_ptr: HashBuiltin* = pedersen_ptr;
@@ -476,35 +333,32 @@ func remove_member{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_p
 }
 
 @external
-func update_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    address: felt, new_role: felt
+func update_roles{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, bitwise_ptr: BitwiseBuiltin*, range_check_ptr}(
+    account: felt, new_roles: felt
 ) {
     alloc_locals;
 
-    require_admin();
-
+    let (caller_address) = get_caller_address();
     let (contract_address) = get_contract_address();
     let (guild_certificate) = _guild_certificate.read();
 
+    AccessControl.has_role(GuildRoles.ADMIN, caller_address);
+
     let (certificate_id: Uint256) = IGuildCertificate.get_certificate_id(
-        contract_address=guild_certificate, owner=address, guild=contract_address
+        contract_address=guild_certificate, owner=account, guild=contract_address
     );
 
-    let member_data = Member(account=address, role=new_role);
+    let roles: felt = AccessControl.get_roles(account);
+    AccessControl.revoke_role(roles, account);
+    AccessControl.grant_role(new_roles, account);
 
-    _whitelisted_role.write(address, new_role);
-
-    IGuildCertificate.update_role(
-        contract_address=guild_certificate, certificate_id=certificate_id, role=new_role
-    );
-
-    MemberRoleUpdated.emit(address, new_role);
+    MemberRoleUpdated.emit(account, new_roles);
 
     return ();
 }
 
 @external
-func deposit{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+func deposit{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, bitwise_ptr: BitwiseBuiltin*, range_check_ptr}(
     token_standard: felt, token: felt, token_id: Uint256, amount: Uint256
 ) {
     alloc_locals;
@@ -513,7 +367,9 @@ func deposit{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     local pedersen_ptr: HashBuiltin* = pedersen_ptr;
     local range_check_ptr = range_check_ptr;
 
-    require_admin_or_owner();
+    let (caller_address) = get_caller_address();
+
+    AccessControl.has_role(GuildRoles.OWNER, caller_address);
 
     let (check_not_zero) = uint256_lt(Uint256(0, 0), amount);
 
@@ -536,7 +392,6 @@ func deposit{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     }
 
     let (guild_certificate) = _guild_certificate.read();
-    let (caller_address) = get_caller_address();
     let (contract_address) = get_contract_address();
 
     let (certificate_id: Uint256) = IGuildCertificate.get_certificate_id(
@@ -644,26 +499,34 @@ func deposit{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
 }
 
 @external
-func withdraw{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+func withdraw{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, bitwise_ptr: BitwiseBuiltin*, range_check_ptr}(
     token_standard: felt, token: felt, token_id: Uint256, amount: Uint256
 ) {
     alloc_locals;
 
+    let (caller_address) = get_caller_address();
+
+    AccessControl.has_role(GuildRoles.OWNER, caller_address);
+
     local syscall_ptr: felt* = syscall_ptr;
     local pedersen_ptr: HashBuiltin* = pedersen_ptr;
     local range_check_ptr = range_check_ptr;
-
-    require_admin_or_owner();
 
     if (token_standard == TokenStandard.ERC721) {
         let (check_one) = uint256_eq(amount, Uint256(1, 0));
         with_attr error_message("Guild Contract: ERC721 amount must be 1") {
             assert check_one = TRUE;
         }
+        tempvar syscall_ptr: felt* = syscall_ptr;
+        tempvar pedersen_ptr: HashBuiltin* = pedersen_ptr;
+        tempvar range_check_ptr = range_check_ptr;
+    } else {
+        tempvar syscall_ptr: felt* = syscall_ptr;
+        tempvar pedersen_ptr: HashBuiltin* = pedersen_ptr;
+        tempvar range_check_ptr = range_check_ptr;
     }
 
     let (guild_certificate) = _guild_certificate.read();
-    let (caller_address) = get_caller_address();
     let (contract_address) = get_contract_address();
 
     let (certificate_id: Uint256) = IGuildCertificate.get_certificate_id(
@@ -756,12 +619,14 @@ func withdraw{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
 }
 
 @external
-func execute_transactions{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+func execute_transactions{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, bitwise_ptr: BitwiseBuiltin*, range_check_ptr}(
     call_array_len: felt, call_array: CallArray*, calldata_len: felt, calldata: felt*, nonce: felt
 ) -> (retdata_len: felt, retdata: felt*) {
     alloc_locals;
-    require_member();
+
     let (caller) = get_caller_address();
+
+    AccessControl.has_role(GuildRoles.MEMBER, caller);
 
     let (calls: Call*) = alloc();
 
@@ -821,7 +686,7 @@ func execute_list{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_pt
 func initialize_permissions{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     permissions_len: felt, permissions: Permission*
 ) {
-    require_master();
+    AccessControl.assert_admin();
 
     let (check_initialized) = _is_permissions_initialized.read();
 

--- a/contracts/interfaces/IGuildCertificate.cairo
+++ b/contracts/interfaces/IGuildCertificate.cairo
@@ -32,13 +32,6 @@ namespace IGuildCertificate {
         ){
     }
 
-    func get_role(
-        certificate_id: Uint256
-    ) -> (
-        role: felt
-    ){
-    }
-
     func get_tokens(
         certificate_id: Uint256
     ) -> (
@@ -76,14 +69,7 @@ namespace IGuildCertificate {
 
     func mint(
             to: felt,
-            guild: felt,
-            role: felt
-        ){
-    }
-
-    func update_role(
-            certificate_id: Uint256,
-            role: felt
+            guild: felt
         ){
     }
 

--- a/contracts/lib/role.cairo
+++ b/contracts/lib/role.cairo
@@ -1,5 +1,5 @@
 namespace GuildRoles {
-    const MEMBER = 1;
-    const OWNER = 2;
-    const ADMIN = 3;
+    const MEMBER = 2 ** 0;
+    const OWNER = 2 ** 1;
+    const ADMIN = 2 ** 2;
 }

--- a/tests/protostar/roles/test_roles.cairo
+++ b/tests/protostar/roles/test_roles.cairo
@@ -24,12 +24,13 @@ func test_grant_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, bitwise_ptr
 @external
 func test_grant_roles{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, bitwise_ptr: BitwiseBuiltin*, range_check_ptr}() {
 
-    AccessControl.grant_role(GuildRoles.MEMBER + GuildRoles.OWNER, FAKE_OWNER_ADDR);
+    AccessControl.grant_role(GuildRoles.MEMBER + GuildRoles.OWNER + GuildRoles.ADMIN, FAKE_OWNER_ADDR);
 
     let roles = AccessControl.get_roles(FAKE_OWNER_ADDR);
 
     AccessControl.has_role(GuildRoles.MEMBER, FAKE_OWNER_ADDR);
     AccessControl.has_role(GuildRoles.OWNER, FAKE_OWNER_ADDR);
+    AccessControl.has_role(GuildRoles.ADMIN, FAKE_OWNER_ADDR);
 
     return();
 }

--- a/tests/protostar/roles/test_roles.cairo
+++ b/tests/protostar/roles/test_roles.cairo
@@ -1,0 +1,52 @@
+%lang starknet
+
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.cairo_builtins import HashBuiltin, BitwiseBuiltin
+
+from contracts.lib.role import GuildRoles
+
+from contracts.access_control.accesscontrol_library import AccessControl
+
+const FAKE_OWNER_ADDR = 20;
+
+@external
+func test_grant_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, bitwise_ptr: BitwiseBuiltin*, range_check_ptr}() {
+
+    AccessControl.grant_role(GuildRoles.MEMBER, FAKE_OWNER_ADDR);
+
+    let role = AccessControl.get_roles(FAKE_OWNER_ADDR);
+
+    assert role = GuildRoles.MEMBER;
+
+    return();
+}
+
+@external
+func test_grant_roles{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, bitwise_ptr: BitwiseBuiltin*, range_check_ptr}() {
+
+    AccessControl.grant_role(GuildRoles.MEMBER + GuildRoles.OWNER, FAKE_OWNER_ADDR);
+
+    let roles = AccessControl.get_roles(FAKE_OWNER_ADDR);
+
+    AccessControl.has_role(GuildRoles.MEMBER, FAKE_OWNER_ADDR);
+    AccessControl.has_role(GuildRoles.OWNER, FAKE_OWNER_ADDR);
+
+    return();
+}
+
+@external
+func test_revoke_all_roles{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, bitwise_ptr: BitwiseBuiltin*, range_check_ptr}() {
+
+    AccessControl.grant_role(GuildRoles.MEMBER, FAKE_OWNER_ADDR);
+    AccessControl.grant_role(GuildRoles.OWNER, FAKE_OWNER_ADDR);
+
+    let roles = AccessControl.get_roles(FAKE_OWNER_ADDR);
+
+    AccessControl.revoke_role(roles, FAKE_OWNER_ADDR);
+
+    let new_roles = AccessControl.get_roles(FAKE_OWNER_ADDR);
+
+    assert new_roles = 0;
+
+    return ();
+}

--- a/tests/pytest/test_proxy.py
+++ b/tests/pytest/test_proxy.py
@@ -132,7 +132,7 @@ async def contract_factory():
         [
             (
                 guild_manager_proxy.contract_address,
-                "deploy_guild_proxy_contract",
+                "deploy_guild",
                 [str_to_felt("Test Guild"), guild_certificate_proxy.contract_address],
             )
         ],
@@ -233,24 +233,16 @@ async def test_adding_members(contract_factory):
         [
             (
                 guild_proxy.contract_address,
-                "whitelist_member",
-                [account2.contract_address, 3],
+                "add_member",
+                [account2.contract_address, 4],
             ),
             (
                 guild_proxy.contract_address,
-                "whitelist_member",
+                "add_member",
                 [account3.contract_address, 2],
             ),
         ],
         [signer1],
-    )
-
-    await TransactionSender(account2).send_transaction(
-        [(guild_proxy.contract_address, "join", [])], [signer2]
-    )
-
-    await TransactionSender(account3).send_transaction(
-        [(guild_proxy.contract_address, "join", [])], [signer3]
     )
 
 
@@ -1003,7 +995,7 @@ async def test_update_role(contract_factory):
         [
             (
                 guild_proxy.contract_address,
-                "update_role",
+                "update_roles",
                 [account3.contract_address, 1],
             )
         ],

--- a/tests/pytest/test_proxy.py
+++ b/tests/pytest/test_proxy.py
@@ -234,12 +234,12 @@ async def test_adding_members(contract_factory):
             (
                 guild_proxy.contract_address,
                 "add_member",
-                [account2.contract_address, 4],
+                [account2.contract_address, 7],
             ),
             (
                 guild_proxy.contract_address,
                 "add_member",
-                [account3.contract_address, 2],
+                [account3.contract_address, 3],
             ),
         ],
         [signer1],
@@ -1023,20 +1023,3 @@ async def test_update_role(contract_factory):
         ],
         [signer3]
     )
-
-    with pytest.raises(StarkException):
-        await sender3.send_transaction(
-            [
-                (
-                    guild_proxy.contract_address,
-                    "deposit",
-                    [
-                        1,
-                        test_nft.contract_address,
-                        *to_uint(10),
-                        *to_uint(1)
-                    ],
-                )
-            ],
-            [signer3]
-        )


### PR DESCRIPTION
Add `accesscontrol_library` with some changes to allow multiple role assignments.

Modifications to the library:

- Allow `grant_role` and `revoke_role` to be used by `GuildRoles.ADMIN`. Reverts when assigning a new role to the guild master (`accesscontrol_admin`).

Add unit tests for roles in protostar. Adjust pytest test for the new role system.

Remove `whitelist_member` and `join` for `add_member`.